### PR TITLE
Adding dimension fields to top page & landing page Aggregate Awareness

### DIFF
--- a/snowplow_web_block.model.lkml
+++ b/snowplow_web_block.model.lkml
@@ -383,10 +383,11 @@ explore: +page_views {
         page_views.page_sub_section,
         cmslite_themes.theme_id,
         cmslite_themes.theme,
+        cmslite_themes.subtheme,
+        cmslite_themes.topic,
+        page_views.geo_city_and_region,
         page_views.page_title,
         page_views.page_display_url,
-        page_views.device_is_mobile,
-        page_views.is_government,
         page_views.page_view_start_date
       ]
       measures: [page_views.row_count]
@@ -399,6 +400,7 @@ explore: +page_views {
       datagroup_trigger: aa_datagroup_cmsl_loaded
     }
   }
+
   aggregate_table: aa__top_landing_pages__7_complete_days__row_count{
     query: {
       dimensions: [
@@ -411,10 +413,11 @@ explore: +page_views {
         page_views.page_sub_section,
         cmslite_themes.theme_id,
         cmslite_themes.theme,
+        cmslite_themes.subtheme,
+        cmslite_themes.topic,
+        page_views.geo_city_and_region,
         page_views.page_title,
         page_views.page_display_url,
-        page_views.device_is_mobile,
-        page_views.is_government,
         page_views.page_view_start_date
       ]
       measures: [page_views.row_count]


### PR DESCRIPTION
to support AA tables filtering against the full (non boolean) set of filters in embed dashboards for the top pages and top landing pages.

device_is_mobile and is_government are removed since filtering on them skips the AA table.