### PR TITLE
Add link between Online Appointments and TheQ (GDXDSD-3492)

### DIFF
--- a/Includes/date_comparisons_common.view.lkml
+++ b/Includes/date_comparisons_common.view.lkml
@@ -1,5 +1,8 @@
 view: date_comparisons_common {
 
+  # NOTE: currently this code is duplicated in the CFMS Block. Please ensure that the two files are kept in sync.
+  #   We'll resolve this conflict in a ticket soon.
+
   # filter_start is a placeholder dimension for the date_comparisons_common view.
 
   # In order to extend this view, this dimension must be modified in the extending view.

--- a/Views/sbc_online_appointments.view.lkml
+++ b/Views/sbc_online_appointments.view.lkml
@@ -23,14 +23,14 @@ view: sbc_online_appointments {
 
       ),
       final_selections AS ( -- this is to assign the location and service as the latest selection
-        SELECT session_id, location, service, appointment_step, ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY step_order DESC, timestamp DESC) AS session_id_ranked
+        SELECT session_id, location, service, appointment_step, appointment_id, client_id, ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY step_order DESC, timestamp DESC) AS session_id_ranked
         FROM raw_list
       )
-      SELECT rl.session_id, fs.location, fs.service, fs.appointment_step, MIN(timestamp) AS min_timestamp, MAX(timestamp) AS max_timestamp,
+      SELECT rl.session_id, fs.location, fs.service, fs.appointment_step, fs.appointment_id, fs.client_id, MIN(timestamp) AS min_timestamp, MAX(timestamp) AS max_timestamp,
         MAX(step_order) AS latest_step
       FROM raw_list AS rl
       JOIN final_selections AS fs ON fs.session_id = rl.session_id AND fs.session_id_ranked = 1
-      GROUP BY 1,2,3,4
+      GROUP BY 1,2,3,4,5,6
           ;;
     distribution_style: all
     datagroup_trigger: datagroup_sbc_online_appointments
@@ -51,6 +51,8 @@ view: sbc_online_appointments {
   }
 
   dimension: appointment_step {}
+  dimension: appointment_id {}
+  dimension: client_id {}
   dimension: latest_step {}
   dimension: session_id {}
   dimension: location {}

--- a/manifest.lkml
+++ b/manifest.lkml
@@ -4,3 +4,9 @@ project_name: "snowplow_web_block"
 local_dependency: {
   project: "cmslite_metadata"
 }
+
+
+# Import CFMS POC to merge SBC TheQ data to Online Appointment booking
+local_dependency: {
+  project: "cfms_block"
+}

--- a/snowplow_web_block.model.lkml
+++ b/snowplow_web_block.model.lkml
@@ -42,6 +42,9 @@ include: "//cmslite_metadata/Views/asset_themes.view.lkml"
 # Import metadata view from cmslite_metadata project
 include: "//cmslite_metadata/Views/metadata.view"
 
+# Import CFMS POC to merge SBC TheQ data to Online Appointment booking
+include: "//cfms_block/Views/cfms_poc.view.lkml"
+
 # hidden city_cache explore supports suggest_explore for the geo filters
 explore: geo_cache {
   hidden: yes
@@ -527,6 +530,12 @@ explore: youtube_embed_video {
 explore: sbc_online_appointments{
   label: "SBC Online Appointments"
   persist_for: "2 hours"
+
+  join: cfms_poc {
+    type: left_outer
+    sql_on: ${cfms_poc.client_id} = ${sbc_online_appointments.client_id} AND ${cfms_poc.service_count}=1 ;;
+    relationship: one_to_one
+  }
 }
 explore: sbc_online_appointments_clicks{
   label: "SBC Online Appointments Clicks"
@@ -766,7 +775,6 @@ explore: health_app_actions {
     user_attribute: urlhost
   }
 }
-
 
 explore: ldb_clicks {
   label: "LDB Actions"


### PR DESCRIPTION
@BJenning @veenupunyani : I had to merge some conflicts to complete this. 

Can you take a look to ensure that I haven't broken anything in your code. 

As well, I removed the wildcard from the
`# Import asset_themes view for asset downloads explore
include: "//cmslite_metadata/Views/*security_groups.view.lkml"
`
The could lead to unexpected behaviour if another view was added to that project. I replaced it with a safer explicit include. 


@BJenning : For the new code, here's an explore that shows it off: 
https://analytics.gov.bc.ca/explore/snowplow_web_block/sbc_online_appointments?qid=b9pQXpwzcovzl9vwZIoq3h&origin_space=37&toggle=dat,vis

This needs to be reviewed in concert with https://github.com/bcgov/GDX-Analytics-Looker-cfms_block/pull/166

**NOTE:** I had to duplicate the date comparison to avoid a recursive include.